### PR TITLE
Reduce the blank lines to a single one

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
             "type": "boolean",
             "default": false,
             "description": "when enabled, inserts a line break just before any @fixture tag that is not at the beginning of a line"
+          },
+          "gherkiner.consecutiveBlankLinesToOne": {
+            "type": "boolean",
+            "default": false,
+            "description": "when enabled, reduces all consecutive blank lines to one"
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import { SettingsProvider, ISettings } from "./settings";
 
 import { File } from "./utils";
-import { Line, LineFactory } from "./line";
+import { Line, LineFactory, Lines } from "./line";
 import { Table, TableLine } from "./table";
 
 // this method is called when your extension is activated
@@ -74,7 +74,9 @@ function buildDocument(
   // Second and next lines are validated against number of cells and the length of every cell is now recalculated.
   // When reached a line not starting with |, if everything is valid, all table rows are updated
   let tab = new Table();
-  // padding for the table is taken from paddingTable, then from paddingDefault and finally set to 0
+  // padding for the table is taken from paddingTable setting.
+  // When not set paddingTable it is taken from paddingDefault.
+  // and finally not set (set to -1) if none of the above is set
   let tabPadding =
     settings.paddingTable > 0
       ? settings.paddingTable
@@ -82,6 +84,7 @@ function buildDocument(
       ? settings.paddingDefault
       : -1;
 
+  let emptyLines = new Lines();
   for (let pos = 0; pos < doc.lineCount; pos++) {
     let line = LineFactory.create(pos, doc);
 
@@ -105,7 +108,20 @@ function buildDocument(
     // if empty line, reset tagLines array, draw table if not empty and continue
     if (line.isEmpty()) {
       tagLines = [];
+
+      // treat the blank line according to the settings, either removing its padding or leaving one
+      if (settings.consecutiveBlankLinesToOne) {
+        emptyLines.append(line);
+      } else {
+        line.updatePadding("", editBuilder);
+      }
       continue;
+    }
+
+    // if not empty line and list of empty lines is not empty, reduce all of them to a single one
+    if (!emptyLines.isEmpty()) {
+      emptyLines.updateContent("", editBuilder);
+      emptyLines.reset();
     }
 
     // if current line starts with @, append its number of line to the array of tag lines until finding

--- a/src/line.ts
+++ b/src/line.ts
@@ -109,3 +109,32 @@ export class Line implements ILine {
         return true;
     }
 }
+
+
+export class Lines {
+    lines: ILine[] = [];
+
+    append(line: ILine) {
+        this.lines.push(line);
+    }
+
+    isEmpty(): boolean {
+        return this.lines.length === 0;
+    }
+
+    reset() {
+        this.lines = [];
+    }
+
+    updateContent(newContent: string, editBuilder: vscode.TextEditorEdit) {
+        let startLine = this.lines[0];
+        let endLine = this.lines[this.lines.length - 1];
+        let startPos = new vscode.Position(startLine.pos, 0);
+        let endPos = new vscode.Position(endLine.pos, endLine.indent + endLine.content.length);
+        let range = new vscode.Range(startPos, endPos);
+        editBuilder.replace(
+            range,
+            newContent,
+        );
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ export interface ISettings {
     paddings: IPadding[]
     formatOnSave: boolean
     fixtureLineBreak: boolean
+    consecutiveBlankLinesToOne: boolean
 }
 
 export class SettingsProvider {
@@ -26,6 +27,7 @@ export class SettingsProvider {
         const paddings = this.readPaddings(cfg);
         const formatOnSave = this.readFormatOnSave(cfg);
         const fixtureLineBreak = this.readFixtureLineBreak(cfg);
+        const consecutiveBlankLinesToOne = this.readConsecutiveBlankLinesToOne(cfg);
 
         return {
             paddingSymbol,
@@ -34,6 +36,7 @@ export class SettingsProvider {
             paddings,
             formatOnSave,
             fixtureLineBreak,
+            consecutiveBlankLinesToOne,
         };
     }
 
@@ -59,5 +62,9 @@ export class SettingsProvider {
 
     private readFixtureLineBreak(cfg: vscode.WorkspaceConfiguration): boolean {
         return cfg.get<boolean>('gherkiner.fixtureLineBreak') ?? false;
+    }
+
+    private readConsecutiveBlankLinesToOne(cfg: vscode.WorkspaceConfiguration): boolean {
+        return cfg.get<boolean>('gherkiner.consecutiveBlankLinesToOne') ?? false;
     }
 }


### PR DESCRIPTION
The setting `consecutiveBlankLinesToOne` set to true reduces all consecutive blank lines in a document to a single one.
When such setting is set to false or not set (default), blank lines are not comprised though any padding they have is removed