### PR TITLE
Normalize line with keyword

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 import { SettingsProvider, ISettings } from "./settings";
 
-import { File } from "./utils";
+import { File, Strings } from "./utils";
 import { Line, LineFactory } from "./line";
 import { Table, TableLine } from "./table";
 
@@ -116,9 +116,19 @@ function buildDocument(
     }
 
     // find a a keyword that matches the line initial string
-    let p = settings.paddings.find((padding) =>
-      padding ? line.isKeywordLine(padding.keyword) : undefined
-    );
+    let p = settings.paddings.find((padding) => {
+      if (padding) {
+        if (line.isKeywordLine(padding.keyword)) {
+          // normalize the line content to have exactly one space after the keyword
+          line.updateContent(
+            Strings.normalizeToJustOneSpaceAfterPrefix(line.content, padding.keyword),
+            editBuilder,
+          );
+          return padding;
+        }
+      }
+      return undefined;
+    });
 
     // use default padding when not found a keywork padding
     let padding = settings.paddingDefault;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,15 @@ export class Strings {
         }
         return arr;
     }
+
+    static normalizeToJustOneSpaceAfterPrefix(content: string, prefix: string): string {
+        /**
+         * This function normalizes the content of a line by removing all the spaces
+         * after the prefix and leaving just one space.
+         */
+        let regex = new RegExp(prefix + "\\s*");
+        return content.replace(regex, prefix + " ");
+    }
 }
 
 export class File {


### PR DESCRIPTION
Lines starting with a configured keyword are normalized to have exactly one blank space just after the keyword